### PR TITLE
FIX(ci): Use maintained base image

### DIFF
--- a/acct-enricher-job-http/Dockerfile
+++ b/acct-enricher-job-http/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubirch/java
+FROM amazoncorretto:8u342
 ARG JAR_LIBS
 ARG JAR_FILE
 ARG VERSION

--- a/acct-enricher-job/Dockerfile
+++ b/acct-enricher-job/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubirch/java
+FROM amazoncorretto:8u342
 ARG JAR_LIBS
 ARG JAR_FILE
 ARG VERSION

--- a/acct-service/Dockerfile
+++ b/acct-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubirch/java
+FROM amazoncorretto:8u342
 ARG JAR_LIBS
 ARG JAR_FILE
 ARG VERSION


### PR DESCRIPTION
This is part of the CVE-2022-2068 fixes.
ubirch/java has not been updated in years.
Switching to the Amazon corretto build of Java 8.

See: OPS-577